### PR TITLE
Fix index horizontal scroll

### DIFF
--- a/assets/pages.css
+++ b/assets/pages.css
@@ -12,7 +12,7 @@
   --focus: #2dd4bf;       /* focus ring */
 }
 
-html, body{ height:100%; }
+html, body{ height:100%; max-width:100%; overflow-x:hidden; }
 *{ box-sizing:border-box; }
 body{
   margin:0; background: var(--bg); color: var(--fg);
@@ -25,6 +25,9 @@ body{
   margin:0 auto; min-height:100vh;
   display:flex; flex-direction:column;
 }
+
+/* Ensure media never causes horizontal overflow */
+img, canvas, video, svg{ max-width:100%; height:auto; }
 
 /* Navigation */
 nav{
@@ -56,7 +59,7 @@ a:focus-visible, button:focus-visible{ outline: 2px solid var(--focus); outline-
 .cta-button.secondary{ background: var(--surface); color: var(--fg); border-color: var(--border); }
 
 /* Cards and Grids */
-.features, .apps-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; margin: 20px 0; }
+.features, .apps-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin: 20px 0; }
 .feature-card, .app-card, .music-card, .bio-card, .experiment-section{
   background: var(--surface); border:1px solid var(--border); border-radius: 10px; padding: 16px;
 }
@@ -81,3 +84,6 @@ footer{ text-align:center; color: var(--muted); padding: 22px 0; border-top: 1px
 canvas{ border-radius: 8px; background: #0b0b0c; }
 
 @media (max-width: 760px){ nav{ border-radius: 8px; padding: 8px 8px; } }
+
+/* Override inline grid min width on index apps grid to avoid overflow */
+.apps-grid{ grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important; }


### PR DESCRIPTION
Make the index page responsive without horizontal scrolling.

The previous layout caused horizontal overflow on smaller screens due to fixed-width elements and grid columns.

---
<a href="https://cursor.com/background-agent?bcId=bc-e47fc41e-67e4-4607-afb2-517f2b1bc3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e47fc41e-67e4-4607-afb2-517f2b1bc3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

