### PR TITLE
Check and make pages responsive

### DIFF
--- a/apps/pomodoro.html
+++ b/apps/pomodoro.html
@@ -18,7 +18,7 @@
       background: linear-gradient(180deg, var(--bg), var(--bg2));
       height: 100dvh; overflow: hidden; /* no scroll */
     }
-    .screen{ position:relative; width:100vw; height:100dvh; overflow:hidden; }
+    .screen{ position:relative; width:100%; height:100dvh; overflow:hidden; }
     /* fixed minimal nav so page never scrolls */
     nav#site-nav{ position: fixed; top: 10px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,.25); border:1px solid var(--border); border-radius: 999px; padding: 6px 10px; z-index: 5; backdrop-filter: blur(10px); }
     nav#site-nav ul{ display:flex; gap:8px; margin:0; padding:0; list-style:none; }

--- a/apps/type-quest.html
+++ b/apps/type-quest.html
@@ -91,7 +91,7 @@
     .letter.next { outline: 4px solid var(--accent); outline-offset: 6px; }
 
     .keyboard { display: grid; gap: 6px; justify-content: center; margin-top: 8px; }
-    .row { display: flex; gap: 6px; justify-content: center; }
+    .row { display: flex; gap: 6px; justify-content: center; flex-wrap: wrap; }
     .key { background: #0c1a36; color: var(--fg); border: 1px solid rgba(255,255,255,.12); border-radius: 10px; padding: 10px 12px; min-width: 36px; text-align: center; font-weight: 800; box-shadow: 0 6px 16px rgba(2,6,23,.25); user-select: none; }
     .key.next { outline: 3px solid var(--accent); outline-offset: 2px; }
     .key.hit { transform: translateY(1px) scale(.98); background: #0a2044; }

--- a/assets/pages.css
+++ b/assets/pages.css
@@ -29,6 +29,9 @@ body{
 /* Ensure media never causes horizontal overflow */
 img, canvas, video, svg{ max-width:100%; height:auto; }
 
+/* Prevent long text/links from causing horizontal overflow */
+:where(h1,h2,h3,p,a,li,button,input){ overflow-wrap:anywhere; }
+
 /* Navigation */
 nav{
   position: sticky; top: 12px; z-index: 10;


### PR DESCRIPTION
Implement responsive fixes to prevent horizontal overflow on several pages.

The changes address specific instances of horizontal scrolling: replacing `100vw` with `100%` in the Pomodoro app, enabling keyboard rows to wrap in the Type Quest game, and adding a global `overflow-wrap:anywhere` rule for text elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-98e1b86c-2f78-4a37-9751-f3e54ba29066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98e1b86c-2f78-4a37-9751-f3e54ba29066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

